### PR TITLE
Default install path checked last for op location

### DIFF
--- a/lib/utils/env.py
+++ b/lib/utils/env.py
@@ -59,7 +59,7 @@ def import_nccl_ops():
 def get_detectron_ops_lib():
     """Retrieve Detectron ops library."""
     # Candidate prefixes for the detectron ops lib path
-    prefixes = [_CMAKE_INSTALL_PREFIX, sys.prefix, sys.exec_prefix] + sys.path
+    prefixes = [sys.prefix, sys.exec_prefix] + sys.path + [_CMAKE_INSTALL_PREFIX]
     # Search for detectron ops lib
     for prefix in prefixes:
         ops_path = os.path.join(prefix, 'lib/libcaffe2_detectron_ops_gpu.so')


### PR DESCRIPTION
If Detectron happens to be installed on the system and someone wants to add their own local installation, they will either add the necessary folders to the python path or the library can be found in the local system path (e.g. the path to the anaconda environment used). With the default install path ("_CMAKE_INSTALL_PREFIX") moved to last position, the system-wide installation won't override the other search paths.